### PR TITLE
Fix carousel image display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -275,6 +275,7 @@ body {
   inset: 0;
   display: block;
   transition: transform 0.5s ease;
+  z-index: 1;
 }
 
 /* 16:9 frame using aspect-ratio; fallback uses padding-top */
@@ -285,12 +286,14 @@ body {
 }
 
 /* Ensure controls and dots remain clickable */
+.carousel-control, .carousel-dots { z-index: 2; }
 
 .carousel-slide {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
+  z-index: 1;
 }
 
 .carousel-slide img {


### PR DESCRIPTION
Add `z-index` to carousel elements to ensure images and controls are visible and clickable.

Previously, a pseudo-element used for aspect ratio enforcement could render above the carousel slides, causing images to be hidden. This change applies `z-index` to the track and slides to bring them forward, and ensures controls and dots remain on top.

---
<a href="https://cursor.com/background-agent?bcId=bc-137d7b83-7221-4bc8-ab13-7852ea8e089e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-137d7b83-7221-4bc8-ab13-7852ea8e089e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

