### PR TITLE
Assign team images to cards

### DIFF
--- a/team.html
+++ b/team.html
@@ -77,7 +77,7 @@
         <!-- Events Team -->
         <div class="team-card" data-team-type="operations" data-team-name="Events Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Events Team" class="team-photo">
+            <img src="Team Images/Events.webp" alt="Events Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-calendar-alt"></i>
             </div>
@@ -95,7 +95,7 @@
         <!-- BPH Team -->
         <div class="team-card" data-team-type="partnerships" data-team-name="Business Partnerships & Outreach (BPH)">
           <div class="team-image">
-            <img src="photo.jpg" alt="Business Partnerships Team" class="team-photo">
+            <img src="Team Images/BPH.webp" alt="Business Partnerships Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-handshake"></i>
             </div>
@@ -113,7 +113,7 @@
         <!-- Design Team -->
         <div class="team-card" data-team-type="creative" data-team-name="Design Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Design Team" class="team-photo">
+            <img src="Team Images/Design.webp" alt="Design Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-palette"></i>
             </div>
@@ -131,7 +131,7 @@
         <!-- Drama Team -->
         <div class="team-card" data-team-type="creative" data-team-name="Drama Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Drama Team" class="team-photo">
+            <img src="Team Images/Drama.webp" alt="Drama Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-theater-masks"></i>
             </div>
@@ -149,7 +149,7 @@
         <!-- Floor Director Team -->
         <div class="team-card" data-team-type="operations" data-team-name="Floor Director Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Floor Director Team" class="team-photo">
+            <img src="Team Images/Floor Director.webp" alt="Floor Director Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-clipboard-list"></i>
             </div>
@@ -167,7 +167,7 @@
         <!-- Fundraising Team -->
         <div class="team-card" data-team-type="finance" data-team-name="Fundraising Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Fundraising Team" class="team-photo">
+            <img src="Team Images/Fundraising.webp" alt="Fundraising Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-dollar-sign"></i>
             </div>
@@ -185,7 +185,7 @@
         <!-- Games Team -->
         <div class="team-card" data-team-type="creative" data-team-name="Games Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Games Team" class="team-photo">
+            <img src="Team Images/Games.webp" alt="Games Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-gamepad"></i>
             </div>
@@ -203,7 +203,7 @@
         <!-- Gift Team -->
         <div class="team-card" data-team-type="operations" data-team-name="Gift Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Gift Team" class="team-photo">
+            <img src="Team Images/Gift.webp" alt="Gift Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-gift"></i>
             </div>
@@ -221,7 +221,7 @@
         <!-- Consumption Team -->
         <div class="team-card" data-team-type="hospitality" data-team-name="Consumption Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Consumption Team" class="team-photo">
+            <img src="Team Images/Consumption.webp" alt="Consumption Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-utensils"></i>
             </div>
@@ -239,7 +239,7 @@
         <!-- MC Team -->
         <div class="team-card" data-team-type="events" data-team-name="MC (Master of Ceremonies) Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="MC Team" class="team-photo">
+            <img src="Team Images/MC.webp" alt="MC Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-microphone"></i>
             </div>
@@ -257,7 +257,7 @@
         <!-- Multimedia Team -->
         <div class="team-card" data-team-type="media" data-team-name="Multimedia Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Multimedia Team" class="team-photo">
+            <img src="Team Images/Multimedia.webp" alt="Multimedia Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-video"></i>
             </div>
@@ -275,7 +275,7 @@
         <!-- Publication Team -->
         <div class="team-card" data-team-type="communications" data-team-name="Publication Team">
           <div class="team-image">
-            <img src="photo.jpg" alt="Publication Team" class="team-photo">
+            <img src="Team Images/Publication.webp" alt="Publication Team" class="team-photo">
             <div class="team-icon-overlay">
               <i class="fas fa-book"></i>
             </div>


### PR DESCRIPTION
Replaced placeholder images on the team page with corresponding images from the `Team Images/` folder to display the correct team photos.

---
<a href="https://cursor.com/background-agent?bcId=bc-03a2f346-2c71-47d8-90ac-6eda803234e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03a2f346-2c71-47d8-90ac-6eda803234e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

